### PR TITLE
Do not declare isReactComponent

### DIFF
--- a/src/ReactHoverObserver.js
+++ b/src/ReactHoverObserver.js
@@ -118,10 +118,14 @@ export default class extends React.Component {
         }
     }
 
+    getIsReactComponent(reactElement) {	
+        return typeof reactElement.type === 'function';	
+    }
+
     shouldDecorateChild(child) {
         return (
             !!child &&
-            typeof child.type === 'function' &&
+            this.getIsReactComponent(child) &&
             this.props.shouldDecorateChildren
         );
     }

--- a/src/ReactHoverObserver.js
+++ b/src/ReactHoverObserver.js
@@ -118,14 +118,10 @@ export default class extends React.Component {
         }
     }
 
-    isReactComponent(reactElement) {
-        return typeof reactElement.type === 'function';
-    }
-
     shouldDecorateChild(child) {
         return (
             !!child &&
-            this.isReactComponent(child) &&
+            typeof child.type === 'function' &&
             this.props.shouldDecorateChildren
         );
     }

--- a/src/ReactHoverObserver.js
+++ b/src/ReactHoverObserver.js
@@ -118,8 +118,8 @@ export default class extends React.Component {
         }
     }
 
-    getIsReactComponent(reactElement) {	
-        return typeof reactElement.type === 'function';	
+    getIsReactComponent(reactElement) {
+        return typeof reactElement.type === 'function';
     }
 
     shouldDecorateChild(child) {


### PR DESCRIPTION
With the React 16.5.0 release, this component's use of `isReactComponent` breaks React's `shouldConstruct` check. Here is a more detailed explanation of the problem: https://github.com/facebook/react/issues/13580

Same as https://github.com/ethanselzer/react-cursor-position/pull/25